### PR TITLE
Fix linter cast error in user model

### DIFF
--- a/app/models/users.ts
+++ b/app/models/users.ts
@@ -2,8 +2,7 @@ import { Sequelize, DataTypes } from 'sequelize';
 import { UserModel } from '../../types/models';
 
 module.exports = (sequelize: Sequelize, DataType: typeof DataTypes): UserModel => {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  const User = <UserModel>sequelize.define(
+  const User = sequelize.define(
     'users',
     {
       username: {
@@ -13,7 +12,7 @@ module.exports = (sequelize: Sequelize, DataType: typeof DataTypes): UserModel =
     {
       timestamps: false
     }
-  );
+  ) as UserModel;
 
   return User;
 };


### PR DESCRIPTION
## Summary

- Remove comment to avoid linter rule. We were using an old way to cast variables. Prefer `as` instead.

## Known Issues

- N/A